### PR TITLE
Update Dockerfile & add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,26 @@
 # Reference: https://nextjs.org/docs/deployment
 
-# Install dependencies only when needed
-FROM node:alpine AS deps
+# Build the source code 
+FROM node:alpine AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
-
-# Rebuild the source code only when needed
-FROM node:alpine AS builder
-WORKDIR /app
 COPY . .
-COPY --from=deps /app/node_modules ./node_modules
+RUN yarn install
 RUN yarn build
 
 # Production image, copy all the files and run next
 FROM node:alpine AS runner
+RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 ENV NODE_ENV production
-
+COPY --from=builder /app/yarn.lock ./
+RUN yarn install --frozen-lockfile --prod
 # You only need to copy next.config.js if you are NOT using the default configuration
 # COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001


### PR DESCRIPTION
I think you don't need an individual steps just for download dependency, just download whatever you want at the moment based on running environment.

Also `--frozen-lock` flag will raise some errors when you are downloading dependency,
So at the first step you can remove this flag to download dependencies and let the yarn/npm to change
the lock file then in the forward use the previous lock file and now you can use `--frozen-lock`

at the production stage we don't need `devDependencies` anymore, so we
install one more time dependencies with the production flag.
This will help to reduce size of final image for docker